### PR TITLE
Claude/intelligent joliot

### DIFF
--- a/src/bot/cogs/pets.py
+++ b/src/bot/cogs/pets.py
@@ -10,12 +10,8 @@ from src.database.database import database
 from src.core import core, logger
 from src.bot import Bot
 from src.utils.images import resize_and_crop
-from src.utils.user import (
-    find_user_or_default,
-    get_time_last_pet,
-    get_pet_cooldown_over,
-    get_pet_cooldown_over_ts,
-)
+from src.utils.user import find_user_or_default
+from src.bot.cogs.shop import get_cooldown_reduction, MIN_COOLDOWN
 
 ROOT_DIR = os.path.dirname(os.path.abspath("__main__"))
 
@@ -23,7 +19,7 @@ ROOT_DIR = os.path.dirname(os.path.abspath("__main__"))
 def get_random_cat():
     taiga_dir = os.path.join(ROOT_DIR, "assets", "taiga")
     taigas = os.listdir(taiga_dir)
-    taiga_file = taigas[random.randint(0, len(taiga_dir) - 1)]
+    taiga_file = random.choice(taigas)
     taiga_path = os.path.join(taiga_dir, taiga_file)
     logger.debug(taiga_path)
     return taiga_path
@@ -63,92 +59,82 @@ class Pet(Cog):
         try:
             # Get user doc
             user_doc: dict = find_user_or_default(ctx.user.id)
+            last_pet = user_doc["lastPet"]
             continue_streak = False
 
-            # Check last pet
-            time_last_pet = get_time_last_pet(user_doc)
-            if time_last_pet:
-                # Calculate time since last pet in regards to cooldown
+            if last_pet is not None:
+                # Parse last pet timestamp
+                date_format = "%Y-%m-%d %H:%M:%S.%f %z"
+                time_last_pet: datetime = (
+                    datetime.strptime(last_pet, date_format)
+                    if isinstance(last_pet, str)
+                    else last_pet
+                )
+                if time_last_pet.tzinfo is None:
+                    time_last_pet = time_last_pet.replace(tzinfo=timezone.utc)
+
                 time_now = datetime.now(timezone.utc)
-                last_pet_dif: timedelta = time_now - time_last_pet
-                pet_cooldown = core.config.data["cooldowns"]["pet"]
+                last_pet_dif = time_now - time_last_pet
+
+                inventory = user_doc.get("inventory", {})
+                base_cooldown = core.config.data["cooldowns"]["pet"]
+                pet_cooldown = max(base_cooldown - get_cooldown_reduction(inventory), MIN_COOLDOWN)
 
                 if not os.getenv("DEV"):
                     if last_pet_dif.total_seconds() < pet_cooldown:
-                        cooldown_over = get_pet_cooldown_over(time_last_pet)
-                        cooldown_over_ts = get_pet_cooldown_over_ts(cooldown_over)
+                        cooldown_over = time_last_pet + timedelta(seconds=pet_cooldown)
+                        cooldown_over_ts = f"<t:{int(cooldown_over.timestamp())}:R>"
 
                         embed = Embed(
                             color=core.config.data["colors"]["error"],
-                            title="Sorry,",
-                            description=f"{core.config.data['bot']['name']} is out exploring right now, please come back {cooldown_over_ts}.",
+                            description=f"{core.config.data['bot']['name']} is sleeping right now. Come back {cooldown_over_ts}.",
                         )
-
                         return await ctx.response.send_message(embed=embed)
 
-                # Check if user has pet in the last 24 hrs
                 if last_pet_dif.total_seconds() < 86400 or os.getenv("DEV"):
                     continue_streak = True
 
-            # Get a random number of beans
+            # Get random number of beans
             new_beans, new_beans_total = calculate_beans(initial=user_doc["beans"])
 
             # Update database
             new_pets = user_doc["pets"] + 1
-            time_now = datetime.now(timezone.utc)
             new_streak = user_doc.get("streak", 0) + 1 if continue_streak else 0
-            set_query = {
-                "beans": new_beans_total,
-                "pets": new_pets,
-                "lastPet": time_now,
-                "streak": new_streak,
-                "highestStreak": max(new_streak, user_doc.get("highestStreak", 0)),
-            }
-
-            # Update doc
             database.users.find_one_and_update(
                 {"_id": str(ctx.user.id)},
-                {"$set": set_query},
+                {"$set": {
+                    "beans": new_beans_total,
+                    "pets": new_pets,
+                    "lastPet": datetime.now(timezone.utc),
+                    "streak": new_streak,
+                    "highestStreak": max(new_streak, user_doc.get("highestStreak", 0)),
+                    "alarmSent": False,
+                }},
             )
 
-            # Get a random taiga picture
+            # Load, crop, and buffer the image
             taiga_path = get_random_cat()
-            taiga_file = File(taiga_path, filename="el_gato.png")
-
-            # Load and reformat the image
             image = Image.open(taiga_path)
             processed_image = resize_and_crop(image, (1000, 1000))
-            rotated_image = processed_image.rotate(0)
-
-            # Save the image to a buffer
             buffer = BytesIO()
-            rotated_image.save(buffer, format="PNG")
+            processed_image.save(buffer, format="PNG")
             buffer.seek(0)
-
-            # Create a file from the buffer
             taiga_file = File(fp=buffer, filename="el_gato.png")
 
-            # Show streak if the streak is greater than or equal to 2
-            fmt_streak = (
-                f"\nYou have a streak of **{new_streak}**!" if new_streak >= 2 else ""
-            )
-
-            # Create embed
+            streak_line = f"\nStreak: **{new_streak}**!" if new_streak >= 2 else ""
             embed = Embed(
-                title=f"You have pet {core.config.data['bot']['name']}",
+                title=f"You pet {core.config.data['bot']['name']}!",
                 color=core.config.data["colors"]["primary"],
-                description=f"""
-{core.config.data['bot']['name']} has given you some beans!
-{core.config.data['emojis']['beans']} `+{new_beans}`
-**Stats**
-{core.config.data['emojis']['heart']} Pets `{new_pets}`
-{core.config.data['emojis']['beans']} Beans `{new_beans_total}`
-{fmt_streak}
-""",
+                description=(
+                    f"{core.config.data['emojis']['beans']} `+{new_beans}` beans\n\n"
+                    f"**Stats**\n"
+                    f"{core.config.data['emojis']['heart']} Pets `{new_pets}`\n"
+                    f"{core.config.data['emojis']['beans']} Beans `{new_beans_total}`"
+                    + streak_line
+                ),
             )
-            embed.set_image(url=f"attachment://el_gato.png")
+            embed.set_image(url="attachment://el_gato.png")
 
-            # Respond
             await ctx.response.send_message(file=taiga_file, embed=embed)
         except Exception as e:
             print_exc()

--- a/src/bot/cogs/profile.py
+++ b/src/bot/cogs/profile.py
@@ -1,13 +1,10 @@
+from datetime import datetime, timezone, timedelta
 from discord import app_commands, Interaction, Embed, User
 from discord.ext.commands import Cog
 from src.core import core
 from src.bot import Bot
 from src.database.database import database
-from src.utils.user import (
-    get_time_last_pet,
-    get_pet_cooldown_over,
-    get_pet_cooldown_over_ts,
-)
+from src.bot.cogs.shop import get_cooldown_reduction, MIN_COOLDOWN
 
 
 class Profile(Cog):
@@ -37,19 +34,28 @@ class Profile(Cog):
             return await ctx.edit_original_response(embed=embed)
 
         # Calculate cooldowns
-        time_last_pet = get_time_last_pet(user_doc)
-        if time_last_pet:
-            cooldown_over = get_pet_cooldown_over(time_last_pet)
-            cooldown_over_ts = get_pet_cooldown_over_ts(cooldown_over)
-        else:
-            cooldown_over_ts = "`has not pet`"
+        last_pet = user_doc.get("lastPet")
+        if last_pet is not None:
+            date_format = "%Y-%m-%d %H:%M:%S.%f %z"
+            time_last_pet: datetime = (
+                datetime.strptime(last_pet, date_format)
+                if isinstance(last_pet, str)
+                else last_pet
+            )
+            if time_last_pet.tzinfo is None:
+                time_last_pet = time_last_pet.replace(tzinfo=timezone.utc)
 
-        # Create embed
+            inventory = user_doc.get("inventory", {})
+            base_cooldown = core.config.data["cooldowns"]["pet"]
+            pet_cooldown = max(base_cooldown - get_cooldown_reduction(inventory), MIN_COOLDOWN)
+            cooldown_over = time_last_pet + timedelta(seconds=pet_cooldown)
+            cooldown_over_ts = f"<t:{int(cooldown_over.timestamp())}:R>"
+        else:
+            cooldown_over_ts = "`never`"
+
         embed = Embed(
             color=core.config.data["colors"]["invisible"],
-            title=f"{user.name}'s Profile",
-            description=f"""\
-""",
+            title=f"{user.display_name}'s Profile",
         )
         embed.add_field(
             name="Stats",
@@ -69,7 +75,6 @@ class Profile(Cog):
         if user.avatar.url:
             embed.set_thumbnail(url=user.avatar.url)
 
-        # Send response
         await ctx.edit_original_response(embed=embed)
 
 

--- a/src/bot/cogs/shop.py
+++ b/src/bot/cogs/shop.py
@@ -1,0 +1,204 @@
+from discord import app_commands, Interaction, Embed
+from discord.ext.commands import Cog
+from src.core import core
+from src.bot import Bot
+from src.database.database import database
+from src.utils.user import find_user_or_default
+
+MIN_COOLDOWN = 3600  # 1 hour floor regardless of items
+
+
+class Item:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        cost: int,
+        ownership_limit: int = 0,
+        emoji: str = "🔹",
+        cooldown_reduction: int = 0,
+    ):
+        self.name = name
+        self.description = description
+        self.cost = cost
+        self.ownership_limit = ownership_limit
+        self.emoji = emoji
+        self.cooldown_reduction = cooldown_reduction  # seconds per item owned
+
+    def fmt_name(self) -> str:
+        return self.name.replace("_", " ").title()
+
+    def fmt_shop_item(self) -> str:
+        notes = []
+        if self.cooldown_reduction > 0:
+            mins = self.cooldown_reduction // 60
+            notes.append(f"−{mins}min cooldown each" if self.ownership_limit != 1 else f"−{mins}min cooldown")
+        if self.ownership_limit > 0:
+            notes.append(f"limit {self.ownership_limit}")
+        subtext = f" · ".join(notes)
+        return (
+            f"{self.emoji} **{self.fmt_name()}** — `{self.cost:,}` beans\n"
+            f"-# {self.description}" + (f" · {subtext}" if subtext else "")
+        )
+
+
+class Items:
+    alarm_clock = Item(
+        "alarm_clock",
+        f"Reminds you when {core.config.data['bot']['name']} can be pet.",
+        cost=50_000,
+        ownership_limit=1,
+        emoji="⏰",
+    )
+
+    cat_toy = Item(
+        "cat_toy",
+        f"Keeps {core.config.data['bot']['name']} from sleeping as long.",
+        cost=100_000,
+        ownership_limit=8,
+        emoji="🧶",
+        cooldown_reduction=3600,
+    )
+
+    catnip = Item(
+        "catnip",
+        f"Gets {core.config.data['bot']['name']} completely wired. Can't sleep like this.",
+        cost=35_000,
+        ownership_limit=4,
+        emoji="🌿",
+        cooldown_reduction=1800,
+    )
+
+    energy_drink = Item(
+        "energy_drink",
+        f"{core.config.data['bot']['name']} doesn't need sleep anymore (she does, but still).",
+        cost=220_000,
+        ownership_limit=1,
+        emoji="⚡",
+        cooldown_reduction=7200,
+    )
+
+
+SHOP_INVENTORY = [Items.alarm_clock, Items.cat_toy, Items.catnip, Items.energy_drink]
+
+ITEM_MAP = {item.name: item for item in SHOP_INVENTORY}
+
+
+def get_cooldown_reduction(inventory: dict) -> int:
+    """Returns total cooldown reduction in seconds from owned items."""
+    reduction = 0
+    for item in SHOP_INVENTORY:
+        count = inventory.get(item.name, 0)
+        reduction += count * item.cooldown_reduction
+    return reduction
+
+
+class Shop(Cog):
+    """Shop cog"""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @app_commands.command(name="shop", description="Open the shop")
+    async def shop(self, ctx: Interaction):
+        items = "\n".join(item.fmt_shop_item() for item in SHOP_INVENTORY)
+
+        embed = Embed(
+            color=core.config.data["colors"]["primary"],
+            title=f"{core.config.data['bot']['name']} Shop",
+            description=items,
+        )
+        embed.set_footer(text="/buy to purchase  ·  /inventory to view your items")
+
+        await ctx.response.send_message(embed=embed)
+
+    @app_commands.command(name="buy", description="Buy an item from the shop")
+    @app_commands.describe(item="The item to purchase")
+    @app_commands.choices(
+        item=[
+            app_commands.Choice(name="⏰ Alarm Clock", value="alarm_clock"),
+            app_commands.Choice(name="🧶 Cat Toy", value="cat_toy"),
+            app_commands.Choice(name="🌿 Catnip", value="catnip"),
+            app_commands.Choice(name="⚡ Energy Drink", value="energy_drink"),
+        ]
+    )
+    async def buy(self, ctx: Interaction, item: app_commands.Choice[str]):
+        shop_item = ITEM_MAP[item.value]
+        user_doc = find_user_or_default(ctx.user.id)
+        inventory = user_doc.get("inventory", {})
+        owned = inventory.get(shop_item.name, 0)
+        beans = user_doc.get("beans", 0)
+        beans_emoji = core.config.data["emojis"]["beans"]
+
+        if shop_item.ownership_limit > 0 and owned >= shop_item.ownership_limit:
+            embed = Embed(
+                color=core.config.data["colors"]["error"],
+                description=f"You already own the maximum of **{shop_item.fmt_name()}** ({shop_item.ownership_limit}).",
+            )
+            return await ctx.response.send_message(embed=embed, ephemeral=True)
+
+        if beans < shop_item.cost:
+            embed = Embed(
+                color=core.config.data["colors"]["error"],
+                description=(
+                    f"Not enough beans. You need {beans_emoji} `{shop_item.cost:,}` "
+                    f"but only have `{beans:,}`."
+                ),
+            )
+            return await ctx.response.send_message(embed=embed, ephemeral=True)
+
+        new_beans = beans - shop_item.cost
+        new_owned = owned + 1
+        database.users.find_one_and_update(
+            {"_id": str(ctx.user.id)},
+            {
+                "$inc": {f"inventory.{shop_item.name}": 1},
+                "$set": {"beans": new_beans},
+            },
+        )
+
+        owned_str = (
+            f"**{new_owned}** / {shop_item.ownership_limit}"
+            if shop_item.ownership_limit > 0
+            else f"**{new_owned}**"
+        )
+        embed = Embed(
+            color=core.config.data["colors"]["primary"],
+            title=f"{shop_item.emoji} {shop_item.fmt_name()}",
+            description=(
+                f"Owned: {owned_str}\n"
+                f"{beans_emoji} `{new_beans:,}` remaining"
+            ),
+        )
+        await ctx.response.send_message(embed=embed)
+
+    @app_commands.command(name="inventory", description="View your items")
+    async def inventory(self, ctx: Interaction):
+        user_doc = find_user_or_default(ctx.user.id)
+        inventory = user_doc.get("inventory", {})
+
+        owned_items = [
+            f"{item.emoji} **{item.fmt_name()}** ×{count}"
+            for item in SHOP_INVENTORY
+            if (count := inventory.get(item.name, 0)) > 0
+        ]
+
+        base_cooldown = core.config.data["cooldowns"]["pet"]
+        reduction = get_cooldown_reduction(inventory)
+        effective = max(base_cooldown - reduction, MIN_COOLDOWN)
+
+        embed = Embed(
+            color=core.config.data["colors"]["primary"],
+            title=f"{ctx.user.display_name}'s Inventory",
+            description="\n".join(owned_items) if owned_items else "No items yet. Check out `/shop`!",
+        )
+        cooldown_value = f"**{effective / 3600:.1f}hrs**"
+        if reduction > 0:
+            cooldown_value += f" (−{reduction // 60}min from items)"
+        embed.add_field(name="Pet Cooldown", value=cooldown_value, inline=False)
+
+        await ctx.response.send_message(embed=embed)
+
+
+async def setup(bot: Bot):
+    await bot.add_cog(Shop(bot))

--- a/src/bot/cogs/shop.py
+++ b/src/bot/cogs/shop.py
@@ -53,7 +53,7 @@ class Items:
 
     cat_toy = Item(
         "cat_toy",
-        f"Keeps {core.config.data['bot']['name']} from sleeping as long.",
+        f"Keeps {core.config.data['bot']['name']} from sleeping as long (−1hr cooldown).",
         cost=100_000,
         ownership_limit=8,
         emoji="🧶",
@@ -62,7 +62,7 @@ class Items:
 
     catnip = Item(
         "catnip",
-        f"Gets {core.config.data['bot']['name']} completely wired. Can't sleep like this.",
+        f"Gets {core.config.data['bot']['name']} wired (-30min cooldown).",
         cost=35_000,
         ownership_limit=4,
         emoji="🌿",
@@ -71,7 +71,7 @@ class Items:
 
     energy_drink = Item(
         "energy_drink",
-        f"{core.config.data['bot']['name']} doesn't need sleep anymore (she does, but still).",
+        f"{core.config.data['bot']['name']} doesn't need sleep anymore (-2hr cooldown).",
         cost=220_000,
         ownership_limit=1,
         emoji="⚡",

--- a/src/bot/cogs/tasks.py
+++ b/src/bot/cogs/tasks.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timezone, timedelta
+from discord import Embed
+from discord.ext import tasks
+from discord.ext.commands import Cog
+import discord
+
+from src.bot import Bot
+from src.core import core, logger
+from src.database.database import database
+from src.bot.cogs.shop import get_cooldown_reduction, MIN_COOLDOWN
+
+
+class Tasks(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.alarm_clock_check.start()
+
+    def cog_unload(self):
+        self.alarm_clock_check.cancel()
+
+    @tasks.loop(seconds=60)
+    async def alarm_clock_check(self):
+        now = datetime.now(timezone.utc)
+        try:
+            cursor = database.users.find({
+                "inventory.alarm_clock": {"$gte": 1},
+                "lastPet": {"$ne": None, "$lte": now - timedelta(seconds=MIN_COOLDOWN)},
+                "alarmSent": {"$ne": True},
+            })
+            for user_doc in cursor:
+                inventory = user_doc.get("inventory", {})
+                base_cooldown = core.config.data["cooldowns"]["pet"]
+                effective_cooldown = max(
+                    base_cooldown - get_cooldown_reduction(inventory), MIN_COOLDOWN
+                )
+
+                last_pet = user_doc["lastPet"]
+                if isinstance(last_pet, str):
+                    last_pet = datetime.strptime(last_pet, "%Y-%m-%d %H:%M:%S.%f %z")
+                if last_pet.tzinfo is None:
+                    last_pet = last_pet.replace(tzinfo=timezone.utc)
+
+                if (now - last_pet).total_seconds() < effective_cooldown:
+                    continue
+
+                # Mark sent BEFORE DM attempt
+                database.users.update_one(
+                    {"_id": user_doc["_id"]},
+                    {"$set": {"alarmSent": True}},
+                )
+
+                try:
+                    discord_user = await self.bot.fetch_user(int(user_doc["_id"]))
+                    embed = Embed(
+                        color=core.config.data["colors"]["primary"],
+                        title=f"⏰ {core.config.data['bot']['name']} is ready to be pet!",
+                        description="Your cooldown has expired. Head back and use `/pet`!",
+                    )
+                    await discord_user.send(embed=embed)
+                    logger.debug(f"Alarm sent to {user_doc['_id']}")
+                except discord.Forbidden:
+                    logger.debug(f"Could not DM {user_doc['_id']} (DMs closed)")
+                except discord.NotFound:
+                    logger.debug(f"User {user_doc['_id']} not found")
+                except Exception as e:
+                    logger.error(f"Alarm DM error for {user_doc['_id']}: {e}")
+
+        except Exception as e:
+            logger.error(f"alarm_clock_check error: {e}")
+
+    @alarm_clock_check.before_loop
+    async def before_alarm_clock_check(self):
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: Bot):
+    await bot.add_cog(Tasks(bot))

--- a/src/utils/user.py
+++ b/src/utils/user.py
@@ -10,6 +10,7 @@ DEFAULT_USER = {
     "beans": 0,
     "streak": 0,
     "highestStreak": 0,
+    "inventory": {},
 }
 
 


### PR DESCRIPTION
**Title:** `feat(shop): finish shop feature`

**Summary:**
- Add `/buy` with autocomplete, ownership limits, and bean balance checks
- Add `/inventory` showing owned items and effective pet cooldown
- Add 🌿 Catnip (−30min each, max 4, 35k beans) and ⚡ Energy Drink (−2hr, max 1, 220k beans) alongside existing Cat Toy
- Wire item reductions into `/pet` and `/profile` so cooldowns are always accurate
- New `tasks.py` cog — polls every 60s, DMs alarm clock owners when their cooldown expires; resets `alarmSent` on each `/pet`

**Bug fixes:**
- `get_random_cat` was using `len(path_string)` instead of `len(file_list)` as the random upper bound
- Removed unused `taiga_file` assignment and no-op `.rotate(0)` in `pets.py`
- Fixed empty embed description and `user.name` → `user.display_name` in `profile.py`